### PR TITLE
Pretty Print Collected Reporting

### DIFF
--- a/task/package.json
+++ b/task/package.json
@@ -9,9 +9,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/table": "^5.0.0",
     "azure-devops-node-api": "^10.1.1",
     "azure-pipelines-task-lib": "^2.10.0",
-    "diff": "^4.0.2"
+    "diff": "^4.0.2",
+    "table": "^5.4.6"
   },
   "devDependencies": {
     "@types/node": "^14.6.0",

--- a/task/src/__mock__/insertion-sort.js
+++ b/task/src/__mock__/insertion-sort.js
@@ -1,6 +1,6 @@
 const insertionSort = (inputArr) => {
     let length = inputArr.length;
-    for (let i = 3; i < length; i++) {
+    for (let i = 1; i < length; i++) {
         let key = inputArr[i];
         let j = i - 1;
         while (j >= 0 && inputArr[j] > key) {

--- a/task/src/__mock__/insertion-sort.js
+++ b/task/src/__mock__/insertion-sort.js
@@ -1,6 +1,6 @@
 const insertionSort = (inputArr) => {
     let length = inputArr.length;
-    for (let i = 1; i < length; i++) {
+    for (let i = 3; i < length; i++) {
         let key = inputArr[i];
         let j = i - 1;
         while (j >= 0 && inputArr[j] > key) {

--- a/task/src/__snapshots__/task.integration.test.ts.snap
+++ b/task/src/__snapshots__/task.integration.test.ts.snap
@@ -21,6 +21,33 @@ exports[`Integration Test should add a landmine but not catch it 2`] = `
 [MockFunction] {
   "calls": Array [
     Array [
+      Array [
+        Array [
+          "File Name",
+          "Line Number",
+          "Bomb Defused",
+        ],
+        Array [
+          "insertion-sort.js",
+          2,
+          "no",
+        ],
+      ],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`Integration Test should add a landmine but not catch it 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
       Object {
         "content": "💥 Bomb not defused. Please adjust your test to catch the error",
       },
@@ -39,7 +66,7 @@ exports[`Integration Test should add a landmine but not catch it 2`] = `
 }
 `;
 
-exports[`Integration Test should add a landmine but not catch it 3`] = `[MockFunction]`;
+exports[`Integration Test should add a landmine but not catch it 4`] = `[MockFunction]`;
 
 exports[`Integration Test should add a landmine but not catch it because the execution timed out 1`] = `
 [MockFunction] {
@@ -62,6 +89,33 @@ exports[`Integration Test should add a landmine but not catch it because the exe
 [MockFunction] {
   "calls": Array [
     Array [
+      Array [
+        Array [
+          "File Name",
+          "Line Number",
+          "Bomb Defused",
+        ],
+        Array [
+          "insertion-sort.js",
+          "7-8",
+          "no",
+        ],
+      ],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`Integration Test should add a landmine but not catch it because the execution timed out 3`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
       Object {
         "content": "💥 Bomb not defused. Please adjust your test to catch the error",
       },
@@ -80,7 +134,7 @@ exports[`Integration Test should add a landmine but not catch it because the exe
 }
 `;
 
-exports[`Integration Test should add a landmine but not catch it because the execution timed out 3`] = `[MockFunction]`;
+exports[`Integration Test should add a landmine but not catch it because the execution timed out 4`] = `[MockFunction]`;
 
 exports[`Integration Test should add two landmines and catch them all 1`] = `
 [MockFunction] {
@@ -100,6 +154,38 @@ exports[`Integration Test should add two landmines and catch them all 1`] = `
 `;
 
 exports[`Integration Test should add two landmines and catch them all 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        Array [
+          "File Name",
+          "Line Number",
+          "Bomb Defused",
+        ],
+        Array [
+          "insertion-sort.js",
+          3,
+          "yes",
+        ],
+        Array [
+          "insertion-sort.js",
+          3,
+          "yes",
+        ],
+      ],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`Integration Test should add two landmines and catch them all 3`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -134,7 +220,7 @@ exports[`Integration Test should add two landmines and catch them all 2`] = `
 }
 `;
 
-exports[`Integration Test should add two landmines and catch them all 3`] = `
+exports[`Integration Test should add two landmines and catch them all 4`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -190,6 +276,8 @@ exports[`Integration Test should not find any landmines because there are no act
 
 exports[`Integration Test should not find any landmines because there are no active threads 3`] = `[MockFunction]`;
 
+exports[`Integration Test should not find any landmines because there are no active threads 4`] = `[MockFunction]`;
+
 exports[`Integration Test should not find any landmines because there are no threads 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -210,3 +298,5 @@ exports[`Integration Test should not find any landmines because there are no thr
 exports[`Integration Test should not find any landmines because there are no threads 2`] = `[MockFunction]`;
 
 exports[`Integration Test should not find any landmines because there are no threads 3`] = `[MockFunction]`;
+
+exports[`Integration Test should not find any landmines because there are no threads 4`] = `[MockFunction]`;

--- a/task/src/__snapshots__/task.integration.test.ts.snap
+++ b/task/src/__snapshots__/task.integration.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Integration Test should add a landmine but not catch it 1`] = `
   "calls": Array [
     Array [
       2,
-      "There was at least bomb that was not defused.",
+      "There was at least one bomb that was not defused.",
     ],
   ],
   "results": Array [
@@ -73,7 +73,7 @@ exports[`Integration Test should add a landmine but not catch it because the exe
   "calls": Array [
     Array [
       2,
-      "There was at least bomb that was not defused.",
+      "There was at least one bomb that was not defused.",
     ],
   ],
   "results": Array [

--- a/task/src/task.integration.test.ts
+++ b/task/src/task.integration.test.ts
@@ -1,10 +1,12 @@
 import tl = require('azure-pipelines-task-lib/task');
 import { WebApi } from 'azure-devops-node-api';
 import {CommentThreadStatus} from "azure-devops-node-api/interfaces/GitInterfaces";
+import { table } from 'table';
 import executeTask from './task';
 
 jest.mock('azure-devops-node-api');
 jest.mock('azure-pipelines-task-lib/task');
+jest.mock('table');
 
 const gitApiMock = {
     getThreads: jest.fn(),
@@ -60,6 +62,7 @@ describe('Integration Test', () => {
         await executeTask();
 
         expect(tl.setResult).toMatchSnapshot();
+        expect(table).toMatchSnapshot();
         expect(gitApiMock.createComment).toMatchSnapshot();
         expect(gitApiMock.updateThread).toMatchSnapshot();
     });
@@ -81,6 +84,7 @@ describe('Integration Test', () => {
         await executeTask();
 
         expect(tl.setResult).toMatchSnapshot();
+        expect(table).toMatchSnapshot();
         expect(gitApiMock.createComment).toMatchSnapshot();
         expect(gitApiMock.updateThread).toMatchSnapshot();
     });
@@ -102,6 +106,7 @@ describe('Integration Test', () => {
         await executeTask();
 
         expect(tl.setResult).toMatchSnapshot();
+        expect(table).toMatchSnapshot();
         expect(gitApiMock.createComment).toMatchSnapshot();
         expect(gitApiMock.updateThread).toMatchSnapshot();
     });
@@ -112,6 +117,7 @@ describe('Integration Test', () => {
         await executeTask();
 
         expect(tl.setResult).toMatchSnapshot();
+        expect(table).toMatchSnapshot();
         expect(gitApiMock.createComment).toMatchSnapshot();
         expect(gitApiMock.updateThread).toMatchSnapshot();
     });
@@ -145,6 +151,7 @@ describe('Integration Test', () => {
         await executeTask();
 
         expect(tl.setResult).toMatchSnapshot();
+        expect(table).toMatchSnapshot();
         expect(gitApiMock.createComment).toMatchSnapshot();
         expect(gitApiMock.updateThread).toMatchSnapshot();
     });

--- a/task/src/task.ts
+++ b/task/src/task.ts
@@ -20,7 +20,7 @@ const outInvalidThreads = (thread: GitPullRequestCommentThread): boolean => {
     return true;
 };
 
-const formatBombReportLine = (bombResult: any): string[] => {
+const extractBombResults = (bombResult: any): string[] => {
     const pathParts = bombResult.filePath.split("/");
     const fileName = pathParts[pathParts.length - 1];
 
@@ -87,13 +87,13 @@ export default async () => {
                 ['File Name', 'Line Number', 'Bomb Defused']
             ];
             for (const bombResult of bombReport) {
-                reportData.push(formatBombReportLine(bombResult));
+                reportData.push(extractBombResults(bombResult));
             }
             console.log(table(reportData));
         }
 
         if (atLeastOneFailure) {
-            throw Error('There was at least bomb that was not defused.')
+            throw Error('There was at least one bomb that was not defused.')
         }
 
         tl.setResult(tl.TaskResult.Succeeded, 'All bombs successfully defused');

--- a/task/src/task.ts
+++ b/task/src/task.ts
@@ -26,7 +26,7 @@ const formatBombReportLine = (bombResult: any): string[] => {
 
     const lineNumbers = bombResult.lineNumberStart === bombResult.lineNumberEnd ? bombResult.lineNumberStart : bombResult.lineNumberStart + '-' + bombResult.lineNumberEnd;
 
-    return [fileName, lineNumbers, bombResult.bombDefused];
+    return [fileName, lineNumbers, bombResult.bombDefused ? 'yes' : 'no'];
 };
 
 export default async () => {
@@ -82,13 +82,15 @@ export default async () => {
             }
         }
 
-        const reportData = [
-            ['File Name', 'Line Number', 'Bomb Defused']
-        ];
-        for (const bombResult of bombReport) {
-            reportData.push(formatBombReportLine(bombResult));
+        if (bombReport.length > 0) {
+            const reportData = [
+                ['File Name', 'Line Number', 'Bomb Defused']
+            ];
+            for (const bombResult of bombReport) {
+                reportData.push(formatBombReportLine(bombResult));
+            }
+            console.log(table(reportData));
         }
-        console.log(table(reportData));
 
         if (atLeastOneFailure) {
             throw Error('There was at least bomb that was not defused.')


### PR DESCRIPTION
Added a post-execution step to print out a grid of the bomb attempt results. The grid print is skipped if there were no bomb attempts.


Example Output:
![image](https://user-images.githubusercontent.com/31460569/91500761-bb5fc200-e889-11ea-86cd-3cdb108f8da0.png)
